### PR TITLE
Book search UI

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class ApiController extends Controller
+{
+    public function search_book(Request $request)
+    {
+        // --- 入力を取得（auther/author 両対応にしておく） ---
+        $query  = trim((string)$request->query('query', ''));
+        $auther = trim((string)$request->query('auther', $request->query('author', '')));
+        $year   = trim((string)$request->query('year', ''));
+        $isbnRaw = trim((string)$request->query('isbn', ''));
+        $isbn = $isbnRaw !== '' ? preg_replace('/[^0-9Xx]/', '', $isbnRaw) : '';
+
+        $language = $request->query('language', null); // "en" / "jpn" / null
+        if ($language === '') $language = null;
+        if (!in_array($language, [null, 'en', 'jpn'], true)) {
+            $language = null; // 想定外は無視
+        }
+
+        $page  = max(1, (int)$request->query('page', 1));
+        $limit = (int)$request->query('limit', 20);
+        $limit = min(50, max(1, $limit)); // 暴走防止（仮）
+
+        // --- ダミー生成（後でここを本実装に差し替える） ---
+        $total = 123; // 仮の総件数
+        $startIndex = ($page - 1) * $limit + 1;
+
+        $items = [];
+        for ($i = 0; $i < $limit; $i++) {
+            $idx = $startIndex + $i;
+            if ($idx > $total) break;
+
+            $items[] = [
+                // フロントの renderList が拾えるように典型キーに寄せる
+                'title' => ($query !== '' ? $query : 'Sample Book') . " #{$idx}",
+                'author_name' => [ $auther !== '' ? $auther : 'Sample Author' ],
+                'first_publish_year' => ($year !== '' ? (int)$year : (2000 + ($idx % 20))),
+                'isbn' => [ $isbn !== '' ? $isbn : ('978000000' . str_pad((string)$idx, 4, '0', STR_PAD_LEFT)) ],
+                'language' => $language,
+            ];
+        }
+
+        $hasMore = ($page * $limit) < $total;
+
+        return response()->json([
+            'items' => $items,
+            'total' => $total,
+            'page' => $page,
+            'limit' => $limit,
+            'has_more' => $hasMore,
+
+            // デバッグ用（不要なら消してOK）
+            'echo' => [
+                'query' => $query,
+                'auther' => $auther,
+                'year' => $year,
+                'isbn' => $isbn,
+                'language' => $language,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -35,14 +35,14 @@ class BookController extends Controller
         $request->validate([
             'book_title' => 'required|string|max:255',
             'author' => 'required|string|max:255',
-            'published_date' => 'required|date',
+            'published_year' => 'required|integer|min:0|max:' . date('Y'),
             'categories' => 'array', // チェックボックスのバリデーション（任意）
         ]);
 
         Book::create([
             'book_title' => $request->book_title,
             'author' => $request->author,
-            'published_date' => $request->published_date,
+            'published_year' => $request->published_year,
             'field'          => implode(',', $request->input('categories', [])),
         ]);
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -39,10 +39,13 @@ class BookController extends Controller
             'categories' => 'array', // チェックボックスのバリデーション（任意）
         ]);
 
+        $publishedYear = (int) $request->published_year;
+
         Book::create([
             'book_title' => $request->book_title,
             'author' => $request->author,
-            'published_year' => $request->published_year,
+            'published_year' => $publishedYear,
+            'published_date' => $publishedYear . '-01-01', // 出版年から出版日を生成
             'field'          => implode(',', $request->input('categories', [])),
         ]);
 

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Carbon;
 
 class Book extends Model
 {
-    protected $fillable = ['book_title', 'author', 'published_year', 'borrower', 'image_path', 'field', 'created_at', 'updated_at'];
+    protected $fillable = ['book_title', 'author', 'published_year', 'published_date', 'borrower', 'image_path', 'field', 'created_at', 'updated_at'];
     
     protected $casts = [
         'updated_at' => 'datetime',

--- a/app/Models/Book.php
+++ b/app/Models/Book.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Carbon;
 
 class Book extends Model
 {
-    protected $fillable = ['book_title', 'author', 'published_date', 'borrower', 'image_path', 'field', 'created_at', 'updated_at'];
+    protected $fillable = ['book_title', 'author', 'published_year', 'borrower', 'image_path', 'field', 'created_at', 'updated_at'];
     
     protected $casts = [
         'updated_at' => 'datetime',

--- a/database/migrations/2026_04_08_070421_really_add_published_year_to_books_table.php
+++ b/database/migrations/2026_04_08_070421_really_add_published_year_to_books_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->integer('published_year')->nullable()->after('author');
+        });
+
+        DB::statement("
+            UPDATE books
+            SET published_year = CAST(strftime('%Y', published_date) AS INTEGER)
+            WHERE published_date IS NOT NULL
+        ");
+    }
+
+    public function down(): void
+    {
+        Schema::table('books', function (Blueprint $table) {
+            $table->dropColumn('published_year');
+        });
+    }
+};

--- a/resources/views/admin.blade.php
+++ b/resources/views/admin.blade.php
@@ -41,8 +41,8 @@
                                 <input type="text" name="author" id="author" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
                             </div>
                             <div>
-                                <label for="published_date" class="block text-sm font-medium text-gray-700">出版日</label>
-                                <input type="date" name="published_date" id="published_date" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" required>
+                                <label for="published_year" class="block text-sm font-medium text-gray-700">出版年</label>
+                                <input type="number" name="published_year" id="published_year" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm" min="0" max="{{ date('Y') }}" required>
                             </div>
                             <div>
                                  <!-- TODO 選択肢の中身をどの分野でカテゴライズするべきか相談 -->
@@ -84,7 +84,7 @@
                                 @foreach($books as $book)
                                     <li class="flex justify-between items-center mb-2">
                                         <span>
-                                            {{ $book->book_title }}（{{ $book->author }} / {{ $book->published_date }}）
+                                            {{ $book->book_title }}（{{ $book->author }} / {{ $book->published_year }}）
                                         </span>
                                         <form action="{{ route('books.destroy', $book->id) }}" method="POST" onsubmit="return confirm('本当に削除しますか？')">
                                             @csrf

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -499,7 +499,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <div class="shrink-0">
               <button
                 type="button"
-                class="add-book-from-result px-3 py-2 rounded-md bg-[var(--color-primary)] text-white text-sm font-semibold hover:opacity-90 transition"
+                class="add-book-from-result px-3 py-2 rounded-md bg-[var(--color-primary)] text-white text-sm font-semibold hover:opacity-90 transition cursor-pointer"
                 data-book='${buttonData}'
               >
                 この本を追加
@@ -509,30 +509,6 @@ document.addEventListener('DOMContentLoaded', function() {
         </div>
       `;
     }).join('');
-
-    document.querySelectorAll('.add-book-from-result').forEach(btn => {
-      btn.addEventListener('click', () => {
-        try {
-          const book = JSON.parse(btn.dataset.book);
-
-          if (selectedBookTitleEl) {
-            selectedBookTitleEl.value = book.title ?? '';
-          }
-          if (selectedAuthorEl) {
-            selectedAuthorEl.value = book.author ?? '';
-          }
-          if (selectedPublishedYearEl) {
-            selectedPublishedYearEl.value = book.published_year ?? '';
-          }
-          if (selectedIsbnEl) {
-            selectedIsbnEl.value = book.isbn ?? '';
-          }
-
-        } catch (e) {
-          console.error('failed to parse book data', e);
-        }
-      });
-    });  
   }
 
   async function fetchAndRender(page) {
@@ -648,6 +624,35 @@ document.addEventListener('DOMContentLoaded', function() {
     nextBtn.classList.add('opacity-50', 'cursor-not-allowed');
 
     updateSearchEnabled();
+  });
+
+  listEl?.addEventListener('click', (e) => {
+    const btn = e.target.closest('.add-book-from-result');
+    if (!btn) return;
+
+    try {
+      const book = JSON.parse(btn.dataset.book);
+
+      if (selectedBookTitleEl) {
+        selectedBookTitleEl.value = book.title ?? '';
+      }
+      if (selectedAuthorEl) {
+        selectedAuthorEl.value = book.author ?? '';
+      }
+      if (selectedPublishedYearEl) {
+        selectedPublishedYearEl.value = book.published_year ?? '';
+      }
+      if (selectedIsbnEl) {
+        selectedIsbnEl.value = book.isbn ?? '';
+      }
+
+      document.getElementById('selected-book-form')?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'nearest',
+      });
+    } catch (err) {
+      console.error('failed to parse book data', err);
+    }
   });
 
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -78,80 +78,578 @@
       {{ session('success') }}
     </div>
   @endif
-  <div class="max-w-2xl mx-auto mt-12 bg-white rounded-xl shadow-lg p-8">
-    <h1 class="text-center text-[var(--color-primary)] text-[var(--text-title)] font-bold mb-8 tracking-wide">すべての図書</h1>
+  <div class="max-w-6xl mx-auto mt-12 bg-white rounded-xl shadow-lg p-8">
+    <h1 class="text-center text-[var(--color-primary)] text-[var(--text-title)] font-bold mb-8 tracking-wide">
+      すべての図書
+    </h1>
 
-    <table class="w-full border-collapse bg-[var(--color-background)] rounded-lg overflow-hidden shadow">
-      <thead>
-        <tr>
-          <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">タイトル</th>
-          <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">著者</th>
-          <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">出版日</th>
-          <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-center text-[var(--text-heading)]">借りる・返却</th>
-        </tr>
-      </thead>
-      <tbody>
-        @foreach($books as $book)
-          <tr class="even:bg-gray-100 hover:bg-[var(--color-accent)]/10 transition">
-            <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->book_title }}</td>
-            <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->author }}</td>
-            <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->published_date }}</td>
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+      {{-- 左：本一覧 --}}
+      <div class="flex-1 min-w-0">
+        <table class="w-full border-collapse bg-[var(--color-background)] rounded-lg overflow-hidden shadow">
+          <thead>
+            <tr>
+              <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">タイトル</th>
+              <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">著者</th>
+              <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-left text-[var(--text-heading)]">出版年</th>
+              <th class="bg-[var(--color-primary)] text-white font-semibold px-6 py-3 text-center text-[var(--text-heading)]">借りる・返却</th>
+            </tr>
+          </thead>
+          <tbody>
+            @foreach($books as $book)
+              <tr class="even:bg-gray-100 hover:bg-[var(--color-accent)]/10 transition">
+                <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->book_title }}</td>
+                <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->author }}</td>
+                <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->published_year }}</td>
 
-            @if (is_null($book->borrower))
-              <td class="px-6 py-4 text-center">
-                <form action="/borrow" method="POST" class="inline borrow-form">
-                  @csrf
-                  <input type="hidden" name="id" value="{{ $book->id }}">
-                  <button type="submit" class="bg-[var(--color-accent)] hover:bg-cyan-400 text-white font-semibold py-2 px-4 rounded transition">借りる</button>
-                </form>
+                @if (is_null($book->borrower))
+                  <td class="px-6 py-4 text-center">
+                    <form action="/borrow" method="POST" class="inline borrow-form">
+                      @csrf
+                      <input type="hidden" name="id" value="{{ $book->id }}">
+                      <button type="submit" class="bg-[var(--color-accent)] hover:bg-cyan-400 text-white font-semibold py-2 px-4 rounded transition">借りる</button>
+                    </form>
 
-                <!-- モーダル -->
-                <div id="modal-bg-{{ $book->id }}-borrow" class="modal-bg">
-                  <div class="modal-content">
-                    <div class="modal-title">あなたの名前を入力してください</div>
-                    <div id="modal-bookinfo-{{ $book->id }}-borrow" style="color:#222; font-size:1rem; margin-bottom:1.5rem; line-height:1.7;">
-                      <!-- 本の情報が入る -->
+                    <!-- モーダル -->
+                    <div id="modal-bg-{{ $book->id }}-borrow" class="modal-bg">
+                      <div class="modal-content">
+                        <div class="modal-title">あなたの名前を入力してください</div>
+                        <div id="modal-bookinfo-{{ $book->id }}-borrow" style="color:#222; font-size:1rem; margin-bottom:1.5rem; line-height:1.7;">
+                          <!-- 本の情報が入る -->
+                        </div>
+                        <div class="modal-btns">
+                          <button id="modal-confirm-{{ $book->id }}-borrow" class="modal-btn confirm">OK</button>
+                          <button id="modal-cancel-{{ $book->id }}-borrow" class="modal-btn cancel">キャンセル</button>
+                        </div>
+                      </div>
                     </div>
-                    <div class="modal-btns">
-                      <button id="modal-confirm-{{ $book->id }}-borrow" class="modal-btn confirm">OK</button>
-                      <button id="modal-cancel-{{ $book->id }}-borrow" class="modal-btn cancel">キャンセル</button>
-                    </div>
-                  </div>
-                </div>
-              </td>
-            @else
-              <td class="px-6 py-4 text-center">
-                <form action="{{ route('books.return', ['id' => $book->id]) }}" method="POST" class="inline return-form">
-                  @csrf
-                  <input type="hidden" name="id" value="{{ $book->id }}">
-                  <button type="submit" class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded transition">返却する</button>
-                </form>
+                  </td>
+                @else
+                  <td class="px-6 py-4 text-center">
+                    <form action="{{ route('books.return', ['id' => $book->id]) }}" method="POST" class="inline return-form">
+                      @csrf
+                      <input type="hidden" name="id" value="{{ $book->id }}">
+                      <button type="submit" class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-4 rounded transition">返却する</button>
+                    </form>
 
-                <!-- モーダル -->
-                <div id="modal-bg-{{ $book->id }}-return" class="modal-bg">
-                  <div class="modal-content">
-                    <div class="modal-title">本当に返却しますか？</div>
-                    <div id="modal-bookinfo-{{ $book->id }}-return" style="color:#222; font-size:1rem; margin-bottom:1.5rem; line-height:1.7;">
-                      <!-- 本の情報が入る -->
+                    <!-- モーダル -->
+                    <div id="modal-bg-{{ $book->id }}-return" class="modal-bg">
+                      <div class="modal-content">
+                        <div class="modal-title">本当に返却しますか？</div>
+                        <div id="modal-bookinfo-{{ $book->id }}-return" style="color:#222; font-size:1rem; margin-bottom:1.5rem; line-height:1.7;">
+                          <!-- 本の情報が入る -->
+                        </div>
+                        <div class="modal-btns">
+                          <button id="modal-confirm-{{ $book->id }}-return" class="modal-btn confirm">OK</button>
+                          <button id="modal-cancel-{{ $book->id }}-return" class="modal-btn cancel">キャンセル</button>
+                        </div>
+                      </div>
                     </div>
-                    <div class="modal-btns">
-                      <button id="modal-confirm-{{ $book->id }}-return" class="modal-btn confirm">OK</button>
-                      <button id="modal-cancel-{{ $book->id }}-return" class="modal-btn cancel">キャンセル</button>
-                    </div>
-                  </div>
-                </div>
-              </td>
-              <td class="hidden">{{ $book->borrower }}</td>
-            @endif
-          </tr>
-        @endforeach
-      </tbody>
-    </table>
+                  </td>
+                  <td class="hidden">{{ $book->borrower }}</td>
+                @endif
+              </tr>
+            @endforeach
+          </tbody>
+      </table>
+    </div>
+
+       {{-- 右：追加/削除ボタン--}}
+      <aside class="w-full lg:w-72">
+        <div class="bg-[var(--color-background)] rounded-xl shadow p-4 border">
+          <div class="text-sm font-semibold text-gray-700 mb-3">管理</div>
+
+          <button id="open-add-book"
+                  class="w-full flex flex-col items-center justify-center p-5
+                         bg-transparent border-2 border-[var(--color-primary)] text-[var(--color-primary)]
+                         rounded-[var(--btn-radius)]
+                         transition duration-200 hover:bg-[var(--color-primary)] hover:text-white hover:scale-[1.02]
+                         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[var(--color-primary)]">
+            <span class="text-base font-bold mb-1">書籍を新しく追加</span>
+            <span class="text-xs opacity-80">新しい書籍情報を登録</span>
+          </button>
+
+          <button id="open-delete-book"
+                  class="w-full mt-4 flex flex-col items-center justify-center p-5
+                         bg-transparent border-2 border-red-500 text-red-500
+                         rounded-[var(--btn-radius)]
+                         transition duration-200 hover:bg-red-500 hover:text-white hover:scale-[1.02]
+                         focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
+            <span class="text-base font-bold mb-1">書籍を削除</span>
+            <span class="text-xs opacity-80">登録済みの書籍を削除</span>
+          </button>
+        </div>
+      </aside>
+
   </div>
+</div>
+
+<div id="modal-bg-add-book" class="modal-bg">
+  <div class="modal-content max-h-[85vh] overflow-auto" style="max-width:720px; text-align:left;">
+    <div class="modal-title">追加したい書籍を検索してください</div>
+
+    <!-- 検索セクション -->
+    <section class="mb-4 p-4 rounded-xl border bg-[var(--color-background)]">
+      <div class="mb-3">
+        <h4 class="font-semibold text-gray-800">Open Libraryで検索</h4>
+        <p class="text-xs text-gray-500 mt-1">
+          キーワード / 著者 / 発行年 / ISBN のいずれかを入力すると検索できます
+        </p>
+      </div>
+
+      <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <div class="sm:col-span-2">
+          <label for="ol_keyword" class="block text-sm font-medium text-gray-700">キーワード</label>
+          <input id="ol_keyword" type="text"
+                 class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                 placeholder="例：量子情報 / Quantum information" />
+          <div>
+            <label for="ol_language" class="block text-sm font-medium text-gray-700">言語</label>
+            <select id="ol_language" class="mt-1 block w-full border-gray-300 rounded-md shadow-sm">
+              <option value="">指定しない</option>
+              <option value="jpn">日本語</option>
+              <option value="en">English</option>
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label for="ol_author" class="block text-sm font-medium text-gray-700">著者</label>
+          <input id="ol_author" type="text"
+                 class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                 placeholder="例：Hotta / ホッタ" />
+        </div>
+
+        <div>
+          <label for="ol_year" class="block text-sm font-medium text-gray-700">発行年</label>
+          <input id="ol_year" type="number" inputmode="numeric"
+                 class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                 placeholder="例：2015" min="1400" max="2100" />
+        </div>
+
+        <div class="sm:col-span-2">
+          <label for="ol_isbn" class="block text-sm font-medium text-gray-700">ISBN</label>
+          <input id="ol_isbn" type="text" inputmode="numeric"
+                 class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                 placeholder="例：978-0000000000（ハイフン可）" />
+        </div>
+      </div>
+
+      <div class="mt-4 flex items-center justify-end gap-2">
+        <button type="button" id="ol_clear_btn"
+                class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50">
+          クリア
+        </button>
+
+        <button type="button" id="ol_search_btn" disabled
+                class="px-4 py-2 rounded-md bg-[var(--color-primary)] text-white font-semibold
+                       opacity-50 cursor-not-allowed transition">
+          検索
+        </button>
+      </div>
+      <!-- 結果表示（メタ情報） -->
+      <div id="ol_results_meta" class="mt-4 text-xs text-gray-600 hidden"></div>
+
+      <!-- 結果表示（一覧） -->
+      <div id="ol_results_list" class="mt-2 space-y-2 hidden"></div>
+
+      <!-- ページャ（最初は非表示） -->
+      <div id="ol_results_pager" class="mt-4 flex items-center justify-between hidden">
+        <button type="button" id="ol_prev_btn"
+                class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+                disabled>
+          前へ
+        </button>
+
+        <div id="ol_page_label" class="text-sm text-gray-700">Page 1</div>
+
+        <button type="button" id="ol_next_btn"
+                class="px-3 py-2 rounded-md border border-gray-300 text-gray-700 hover:bg-gray-50 opacity-50 cursor-not-allowed"
+                disabled>
+          次へ
+        </button>
+      </div>
+
+    </section>
+
+    <section class="mt-4 p-4 rounded-xl border bg-white">
+      <h4 class="font-semibold text-gray-800 mb-3">選択した書籍を登録</h4>
+
+      <form id="selected-book-form" action="{{ route('books.store') }}" method="POST" class="space-y-4">
+        @csrf
+
+        <div>
+          <label for="selected_book_title" class="block text-sm font-medium text-gray-700">書籍タイトル</label>
+          <input id="selected_book_title" name="book_title" type="text"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                required>
+        </div>
+
+        <div>
+          <label for="selected_author" class="block text-sm font-medium text-gray-700">著者</label>
+          <input id="selected_author" name="author" type="text"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                required>
+        </div>
+
+        <div>
+          <label for="selected_published_year" class="block text-sm font-medium text-gray-700">出版年</label>
+          <input id="selected_published_year" name="published_year" type="number"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                min="0" max="{{ date('Y') }}" required>
+        </div>
+
+        <div>
+          <label for="selected_isbn" class="block text-sm font-medium text-gray-700">ISBN</label>
+          <input id="selected_isbn" type="text"
+                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm"
+                readonly>
+          <p class="mt-1 text-xs text-gray-500">ISBN は表示のみです。今はDB保存には使いません。</p>
+        </div>
+
+        <div>
+          <label class="block text-sm font-medium text-gray-700">カテゴリ</label>
+          <div class="flex flex-col mt-1">
+            <label><input type="checkbox" name="categories[]" value="選択肢1"> 選択肢1</label>
+            <label><input type="checkbox" name="categories[]" value="選択肢2"> 選択肢2</label>
+            <label><input type="checkbox" name="categories[]" value="選択肢3"> 選択肢3</label>
+          </div>
+        </div>
+
+        <div class="flex justify-end">
+          <button type="submit"
+                  class="px-4 py-2 rounded-md bg-[var(--color-primary)] text-white font-semibold hover:opacity-90 transition">
+            登録する
+          </button>
+        </div>
+      </form>
+    </section>
+
+    <!-- フッター（いまは閉じるだけ） -->
+    <div class="modal-btns" style="justify-content:flex-end; margin-top:1rem;">
+      <button type="button" id="cancel-add-book" class="modal-btn cancel">閉じる</button>
+    </div>
+  </div>
+</div>
+<div id="modal-bg-delete-book" class="modal-bg">
+  <div class="modal-content" style="max-width:640px; text-align:left;">
+    <div class="modal-title" style="color:#ef4444;">登録した書籍情報を削除できます</div>
+
+    <div class="text-sm text-gray-700 max-h-[60vh] overflow-auto">
+      <ul class="space-y-2">
+        @foreach($books as $book)
+          <li class="flex items-center justify-between gap-3 border rounded-lg p-3 bg-white">
+            <div class="min-w-0">
+              <div class="font-semibold truncate">{{ $book->book_title }}</div>
+              <div class="text-xs text-gray-500">{{ $book->author }} / {{ $book->published_year }}</div>
+            </div>
+
+            <form action="{{ route('books.destroy', $book->id) }}"
+                  method="POST"
+                  onsubmit="return confirm('本当に削除しますか？')">
+              @csrf
+              @method('DELETE')
+              <button type="submit"
+                      class="bg-red-500 hover:bg-red-600 text-white font-semibold py-2 px-3 rounded transition">
+                削除
+              </button>
+            </form>
+          </li>
+        @endforeach
+      </ul>
+    </div>
+
+    <div class="modal-btns" style="justify-content:flex-end;">
+      <button type="button" id="close-delete-book" class="modal-btn cancel">閉じる</button>
+    </div>
+  </div>
+</div>
+
 
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   let targetForm = null;
+
+  // 追加・削除モーダルの処理
+  const addBg = document.getElementById('modal-bg-add-book');
+  const delBg = document.getElementById('modal-bg-delete-book');
+
+  document.getElementById('open-add-book')?.addEventListener('click', () => addBg?.classList.add('active'));
+  document.getElementById('open-delete-book')?.addEventListener('click', () => delBg?.classList.add('active'));
+
+  document.getElementById('cancel-add-book')?.addEventListener('click', () => addBg?.classList.remove('active'));
+  document.getElementById('close-delete-book')?.addEventListener('click', () => delBg?.classList.remove('active'));
+
+  addBg?.addEventListener('click', (e) => { if (e.target === addBg) addBg.classList.remove('active'); });
+  delBg?.addEventListener('click', (e) => { if (e.target === delBg) delBg.classList.remove('active'); });
+
+  const keywordEl = document.getElementById('ol_keyword');
+  const authorEl  = document.getElementById('ol_author');
+  const yearEl    = document.getElementById('ol_year');
+  const isbnEl    = document.getElementById('ol_isbn');
+  const searchBtn = document.getElementById('ol_search_btn');
+  const clearBtn  = document.getElementById('ol_clear_btn');
+
+  const metaEl    = document.getElementById('ol_results_meta');
+  const listEl    = document.getElementById('ol_results_list');
+  const pagerEl   = document.getElementById('ol_results_pager');
+  const prevBtn   = document.getElementById('ol_prev_btn');
+  const nextBtn   = document.getElementById('ol_next_btn');
+  const pageLabel = document.getElementById('ol_page_label');
+  const selectedBookTitleEl = document.getElementById('selected_book_title');
+  const selectedAuthorEl = document.getElementById('selected_author');
+  const selectedPublishedYearEl = document.getElementById('selected_published_year');
+  const selectedIsbnEl = document.getElementById('selected_isbn');
+
+  const langEl = document.getElementById('ol_language');
+  const SEARCH_URL = `{{ route('api.search_book') }}`;
+  const PER_PAGE = 20;
+
+  let currentPage = 1;
+  let lastParams = null;
+
+  function norm(v) { return (v ?? '').toString().trim(); }
+
+  function buildParams(page) {
+    return {
+      query: norm(keywordEl?.value),
+      auther: norm(authorEl?.value),   // ← 要件どおり "auther" で送る
+      year: norm(yearEl?.value),
+      isbn: norm(isbnEl?.value),
+      language: norm(langEl?.value) || null, // ""ならnull扱い
+      page: page,
+      limit: PER_PAGE,
+    };
+  }
+
+  function anyFilled(p) {
+    return !!(p.query || p.auther || p.year || p.isbn);
+  }
+
+  function toQueryString(params) {
+    const qs = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (v === null || v === undefined) continue;
+      if (typeof v === 'string' && v.trim() === '') continue;
+      qs.append(k, v);
+    }
+    return qs.toString();
+  }
+
+  function esc(s){ return String(s ?? '').replace(/[&<>"']/g, m => ({
+    '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
+  }[m]));}
+
+  function renderList(items){
+    metaEl.classList.remove('hidden');
+    listEl.classList.remove('hidden');
+    pagerEl.classList.remove('hidden');
+
+    if (!items || items.length === 0) {
+      listEl.innerHTML = `
+        <div class="rounded-lg border bg-white p-4 text-sm text-gray-600">
+          該当する書籍は見つかりませんでした
+        </div>
+      `;
+      return;
+    }
+
+    listEl.innerHTML = items.map((it, idx) => {
+      const rawTitle  = it.title ?? it.book_title ?? it.name ?? '';
+      const rawAuthor = it.author ?? it.auther ?? it.author_name?.[0] ?? '';
+      const rawYear   = it.year ?? it.first_publish_year ?? '';
+      const rawIsbn   = Array.isArray(it.isbn) ? (it.isbn[0] ?? '') : (it.isbn ?? '');
+
+      const title  = esc(rawTitle || '(no title)');
+      const author = esc(rawAuthor || '不明');
+      const year   = esc(rawYear || '不明');
+      const isbn   = esc(rawIsbn || '');
+
+      const buttonData = esc(JSON.stringify({
+        title: rawTitle || '',
+        author: rawAuthor || '',
+        published_year: rawYear || '',
+        isbn: rawIsbn || ''
+      }));
+
+      return `
+        <div class="rounded-xl border border-gray-200 bg-white p-4 shadow-sm">
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0 flex-1">
+              <div class="text-base font-semibold text-gray-900 break-words">
+                ${title}
+              </div>
+
+              <div class="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-2 text-sm text-gray-700">
+                <div>
+                  <span class="font-medium text-gray-500">著者</span><br>
+                  <span>${author}</span>
+                </div>
+                <div>
+                  <span class="font-medium text-gray-500">出版年</span><br>
+                  <span>${year}</span>
+                </div>
+                <div class="sm:col-span-2">
+                  <span class="font-medium text-gray-500">ISBN</span><br>
+                  <span>${isbn || 'なし'}</span>
+                </div>
+              </div>
+            </div>
+
+            <div class="shrink-0">
+              <button
+                type="button"
+                class="add-book-from-result px-3 py-2 rounded-md bg-[var(--color-primary)] text-white text-sm font-semibold hover:opacity-90 transition"
+                data-book='${buttonData}'
+              >
+                この本を追加
+              </button>
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+
+    document.querySelectorAll('.add-book-from-result').forEach(btn => {
+      btn.addEventListener('click', () => {
+        try {
+          const book = JSON.parse(btn.dataset.book);
+
+          if (selectedBookTitleEl) {
+            selectedBookTitleEl.value = book.title ?? '';
+          }
+          if (selectedAuthorEl) {
+            selectedAuthorEl.value = book.author ?? '';
+          }
+          if (selectedPublishedYearEl) {
+            selectedPublishedYearEl.value = book.published_year ?? '';
+          }
+          if (selectedIsbnEl) {
+            selectedIsbnEl.value = book.isbn ?? '';
+          }
+
+        } catch (e) {
+          console.error('failed to parse book data', e);
+        }
+      });
+    });  
+  }
+
+  async function fetchAndRender(page) {
+    const params = { ...lastParams, page, limit: PER_PAGE };
+    const url = `${SEARCH_URL}?${toQueryString(params)}`;
+
+    // 表示を一旦クリア
+    metaEl.textContent = '';
+    listEl.innerHTML = `<div class="text-sm text-gray-600">読み込み中...</div>`;
+
+    try {
+      const resp = await fetch(url, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const data = await resp.json();
+
+      // 返却形式はどちらでも対応できるように
+      const items = data.items ?? data.docs ?? [];
+      const total = (typeof data.total === 'number') ? data.total
+                  : (typeof data.numFound === 'number') ? data.numFound
+                  : null;
+
+      renderList(items);
+
+      // 次へ判定：totalがあれば厳密、無ければ「20件返ってきたら次があるかも」
+      const hasMore = (typeof data.has_more === 'boolean')
+        ? data.has_more
+        : (typeof total === 'number')
+          ? (page * PER_PAGE < total)
+          : (items.length === PER_PAGE);
+
+      // ページャ更新
+      currentPage = page;
+      pageLabel.textContent = `Page ${page}`;
+
+      prevBtn.disabled = page <= 1;
+      prevBtn.classList.toggle('opacity-50', prevBtn.disabled);
+      prevBtn.classList.toggle('cursor-not-allowed', prevBtn.disabled);
+
+      nextBtn.disabled = !hasMore;
+      nextBtn.classList.toggle('opacity-50', nextBtn.disabled);
+      nextBtn.classList.toggle('cursor-not-allowed', nextBtn.disabled);
+
+      // メタ表示
+      metaEl.textContent = (typeof total === 'number')
+        ? `表示: ${items.length}件 / 総件数: ${total}件`
+        : `表示: ${items.length}件`;
+
+    } catch (e) {
+      listEl.innerHTML = `<div class="text-sm text-red-600">取得に失敗しました</div>`;
+      nextBtn.disabled = true;
+      nextBtn.classList.add('opacity-50', 'cursor-not-allowed');
+    }
+  }
+
+  // 検索ボタン：page=1で実行
+  searchBtn.addEventListener('click', () => {
+    const p = buildParams(1);
+    if (!anyFilled(p)) return;
+    lastParams = p;
+    fetchAndRender(1);
+  });
+
+  // 次へ/前へ
+  nextBtn.addEventListener('click', () => {
+    if (!lastParams) return;
+    fetchAndRender(currentPage + 1);
+  });
+
+  prevBtn.addEventListener('click', () => {
+    if (!lastParams || currentPage <= 1) return;
+    fetchAndRender(currentPage - 1);
+  });
+
+  // 入力に応じて検索ボタン有効化（languageは条件に含めない）
+  function updateSearchEnabled() {
+    const p = buildParams(currentPage);
+    const ok = anyFilled(p);
+    searchBtn.disabled = !ok;
+    searchBtn.classList.toggle('opacity-50', !ok);
+    searchBtn.classList.toggle('cursor-not-allowed', !ok);
+  }
+  [keywordEl, authorEl, yearEl, isbnEl].forEach(el => {
+    el.addEventListener('input', updateSearchEnabled);
+    el.addEventListener('change', updateSearchEnabled);
+  });
+  updateSearchEnabled();
+
+  clearBtn?.addEventListener('click', () => {
+    keywordEl.value = '';
+    authorEl.value = '';
+    yearEl.value = '';
+    isbnEl.value = '';
+    if (langEl) langEl.value = '';
+
+    if (selectedBookTitleEl) selectedBookTitleEl.value = '';
+    if (selectedAuthorEl) selectedAuthorEl.value = '';
+    if (selectedPublishedYearEl) selectedPublishedYearEl.value = '';
+    if (selectedIsbnEl) selectedIsbnEl.value = '';
+
+    lastParams = null;
+    currentPage = 1;
+
+    metaEl.textContent = '';
+    listEl.innerHTML = '';
+    metaEl.classList.add('hidden');
+    listEl.classList.add('hidden');
+    pagerEl.classList.add('hidden');
+
+    pageLabel.textContent = 'Page 1';
+    prevBtn.disabled = true;
+    nextBtn.disabled = true;
+    prevBtn.classList.add('opacity-50', 'cursor-not-allowed');
+    nextBtn.classList.add('opacity-50', 'cursor-not-allowed');
+
+    updateSearchEnabled();
+  });
+
 
   // 借りるボタンのモーダル処理
   document.querySelectorAll('.borrow-form').forEach(form => {

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Models\Book;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\BookController;
+use App\Http\Controllers\ApiController;
 
 // テスト画面
 Route::get('/', function () {
@@ -51,3 +52,7 @@ Route::get('/borrowing-records', [BookController::class, 'index'])->name('books.
 Route::post('/books/{id}/return', [BookController::class, 'return'])->name('books.return');
 Route::post('/borrow', [BookController::class, 'borrow']);
 Route::post('/return', [BookController::class, 'return']);
+
+// APIエンドポイント
+Route::get('/api/search_book', [ApiController::class, 'search_book'])
+    ->name('api.search_book');


### PR DESCRIPTION
やったこと

- published_yearベースの表示、登録の対応にした
- 検索結果一覧のUI実装
- 検索結果から登録フォームへ値をセットする流れの実装
- ダミーデータで検索→選択→登録までは確認済

これからの実装

- api.search_bookで実データを返す処理
- 実API接続
- フロントにデータを返却
```json
{
  "items": [
    {
      "title": "本のタイトル", 
      "author_name": ["著者名"],
      "first_publish_year": 2020,
      "isbn": ["9781234567890"]
    }
  ],
  "total": 123,
  "has_more": true
}
```

こんな感じ

未対応事項

- ISBNのDB保存
- published_dateの扱い(いずれは完全にpublished_yearに統合したい)