### PR TITLE
書籍検索API連携を実装

### DIFF
--- a/app/Http/Controllers/ApiController.php
+++ b/app/Http/Controllers/ApiController.php
@@ -17,34 +17,94 @@ class ApiController extends Controller
         $isbn = $isbnRaw !== '' ? preg_replace('/[^0-9Xx]/', '', $isbnRaw) : '';
 
         $language = $request->query('language', null); // "en" / "jpn" / null
-        if ($language === '') $language = null;
-        if (!in_array($language, [null, 'en', 'jpn'], true)) {
-            $language = null; // 想定外は無視
+        if ($language === '') {
+            $language = null;
         }
+
+        if (!in_array($language, [null, 'en', 'jpn'], true)) {
+            $language = null;
+        }
+
+        // Open Library API用の言語コードに変換
+        $openLibraryLanguage = match ($language) {
+            'en' => 'eng',
+            'jpn' => 'jpn',
+            default => null,
+        };
 
         $page  = max(1, (int)$request->query('page', 1));
         $limit = (int)$request->query('limit', 20);
         $limit = min(50, max(1, $limit)); // 暴走防止（仮）
 
-        // --- ダミー生成（後でここを本実装に差し替える） ---
-        $total = 123; // 仮の総件数
-        $startIndex = ($page - 1) * $limit + 1;
-
-        $items = [];
-        for ($i = 0; $i < $limit; $i++) {
-            $idx = $startIndex + $i;
-            if ($idx > $total) break;
-
-            $items[] = [
-                // フロントの renderList が拾えるように典型キーに寄せる
-                'title' => ($query !== '' ? $query : 'Sample Book') . " #{$idx}",
-                'author_name' => [ $auther !== '' ? $auther : 'Sample Author' ],
-                'first_publish_year' => ($year !== '' ? (int)$year : (2000 + ($idx % 20))),
-                'isbn' => [ $isbn !== '' ? $isbn : ('978000000' . str_pad((string)$idx, 4, '0', STR_PAD_LEFT)) ],
-                'language' => $language,
-            ];
+        // 何も入力されていない場合は検索しない
+        if($query == '' && $auther == '' && $year == '' && $isbn == '') {
+            return response()->json([
+                'items' => [],
+                'total' => 0,
+                'page' => $page,
+                'limit' => $limit,
+                'has_more' => false,
+            ]);
         }
 
+        // Open Library API用のパラメータ作成
+        $params = [
+            'page' => $page,
+            'limit' => $limit,
+            'fields' => 'key,title,author_name,first_publish_year,isbn,language',
+        ];
+
+        //isbnがある場合はそれで優先して検索
+        if ($isbn !== '') {
+            $params['isbn'] = $isbn;
+        } else {
+            if ($query !== '') {
+                // q は総合検索
+                $params['q'] = $query;
+            }
+
+            if ($auther !== '') {
+                $params['author'] = $auther;
+            }
+
+            if ($year !== '') {
+                $params['first_publish_year'] = $year;
+            }
+
+            if ($openLibraryLanguage !== null) {
+                $params['language'] = $openLibraryLanguage;
+            }
+        }
+
+        try {
+            $response = Http::timeout(10)
+                ->acceptJson()
+                ->get('https://openlibrary.org/search.json', $params);
+
+            if (!$response->successful()) {
+                return response()->json([
+                    'message' => 'Open Library APIの取得に失敗しました',
+                    'status' => $response->status(),
+                    'body' => $response->body(),
+                ], 502, [], JSON_UNESCAPED_UNICODE);
+            }
+
+            $data = $response->json();
+
+            $docs = $data['docs'] ?? [];
+            $total = (int) ($data['numFound'] ?? count($docs));
+
+            // フロント側が扱いやすい形に整形
+            $items = collect($docs)->map(function ($book) {
+                return [
+                    'title' => $book['title'] ?? '',
+                    'author_name' => $book['author_name'] ?? [],
+                    'first_publish_year' => $book['first_publish_year'] ?? null,
+                    'isbn' => $book['isbn'] ?? [],
+                    'language' => $book['language'] ?? [],
+                ];
+            })->values();
+        
         $hasMore = ($page * $limit) < $total;
 
         return response()->json([
@@ -55,14 +115,23 @@ class ApiController extends Controller
             'has_more' => $hasMore,
 
             // デバッグ用（不要なら消してOK）
-            'echo' => [
-                'query' => $query,
-                'auther' => $auther,
-                'year' => $year,
-                'isbn' => $isbn,
-                'language' => $language,
-            ],
-        ]);
+                'echo' => [
+                    'query' => $query,
+                    'auther' => $auther,
+                    'year' => $year,
+                    'isbn' => $isbn,
+                    'language' => $language,
+                    'open_library_language' => $openLibraryLanguage,
+                    'params' => $params,
+                ],
+            ], 200, [], JSON_UNESCAPED_UNICODE);
+
+        } catch (\Throwable $e) {
+            return response()->json([
+                'message' => 'API接続中にエラーが発生しました',
+                'error' => $e->getMessage(),
+            ], 500, [], JSON_UNESCAPED_UNICODE);
+        }
     }
 }
 

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -16,12 +16,16 @@ class BookController extends Controller
     public function return($id)
     {
         $book = Book::findOrFail($id);
+
+        $title = $book->book_title;
+
         $book->borrower = null;
         $book->save();
-        return redirect()->back();
-    }
 
-    
+        return redirect()
+            ->back()
+            ->with('book_returned', '「' . $title . '」を返却しました。');
+    }
 
     public function admin_index()
     {
@@ -29,36 +33,43 @@ class BookController extends Controller
         return view('admin', compact('books'));
     }
 
-    // 新規書籍登録
-    public function store(Request $request)
-    {
-        $request->validate([
-            'book_title' => 'required|string|max:255',
-            'author' => 'required|string|max:255',
-            'published_year' => 'required|integer|min:0|max:' . date('Y'),
-            'categories' => 'array', // チェックボックスのバリデーション（任意）
-        ]);
+// 新規書籍登録
+public function store(Request $request)
+{
+    $request->validate([
+        'book_title' => 'required|string|max:255',
+        'author' => 'required|string|max:255',
+        'published_year' => 'required|integer|min:0|max:' . date('Y'),
+        'categories' => 'array',
+    ]);
 
-        $publishedYear = (int) $request->published_year;
+    $publishedYear = (int) $request->published_year;
 
-        Book::create([
-            'book_title' => $request->book_title,
-            'author' => $request->author,
-            'published_year' => $publishedYear,
-            'published_date' => $publishedYear . '-01-01', // 出版年から出版日を生成
-            'field'          => implode(',', $request->input('categories', [])),
-        ]);
+    $book = Book::create([
+        'book_title' => $request->book_title,
+        'author' => $request->author,
+        'published_year' => $publishedYear,
+        'published_date' => $publishedYear . '-01-01',
+        'field' => implode(',', $request->input('categories', [])),
+    ]);
 
-        return redirect()->back()->with('success', '書籍を追加しました');
-    }
+    return redirect()
+        ->back()
+        ->with('book_added', '「' . $book->book_title . '」を登録しました。');
+}
 
-    public function destroy($id)
-    {
-        $book = Book::findOrFail($id); // 指定されたIDのBookを取得
-        $book->delete();               // 削除
+public function destroy($id)
+{
+    $book = Book::findOrFail($id);
 
-        return redirect()->back()->with('success', '書籍を削除しました');
-    }
+    $title = $book->book_title;
+
+    $book->delete();
+
+    return redirect()
+        ->back()
+        ->with('book_deleted', '「' . $title . '」を削除しました。');
+}
     
     public function admin()
     {
@@ -66,14 +77,19 @@ class BookController extends Controller
         return view('admin', compact('books'));
     }
 
-    public function borrow(Request $request) {
+    public function borrow(Request $request)
+    {
         $request->validate([
             'id' => 'required|exists:books,id',
             'borrower' => 'required|string|max:255',
         ]);
 
-        Book::where('id', $request->id)
-            ->update(['borrower' => $request->borrower]);
-        return redirect()->back()->with('success', '本を借りました。');
+        $book = Book::findOrFail($request->id);
+        $book->borrower = $request->borrower;
+        $book->save();
+
+        return redirect()
+            ->back()
+            ->with('book_borrowed', '「' . $book->book_title . '」を貸出中にしました。');
     }
 }

--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -50,7 +50,7 @@ class BookController extends Controller
         'author' => $request->author,
         'published_year' => $publishedYear,
         'published_date' => $publishedYear . '-01-01',
-        'field' => implode(',', $request->input('categories', [])),
+        'location' => $request->input('location'),
     ]);
 
     return redirect()

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -73,11 +73,93 @@
   </style>
 </head>
 <body>
-  @if (session('success'))
-    <div style="color: green; margin-bottom: 10px;">
-      {{ session('success') }}
+@php
+  $flash = null;
+
+  if (session('book_added')) {
+      $flash = [
+          'type' => 'success',
+          'title' => '書籍を追加しました',
+          'message' => session('book_added'),
+          'color' => 'emerald',
+          'icon' => '✓',
+      ];
+  } elseif (session('book_deleted')) {
+      $flash = [
+          'type' => 'danger',
+          'title' => '書籍を削除しました',
+          'message' => session('book_deleted'),
+          'color' => 'red',
+          'icon' => '×',
+      ];
+  } elseif (session('book_borrowed')) {
+      $flash = [
+          'type' => 'info',
+          'title' => '貸出処理が完了しました',
+          'message' => session('book_borrowed'),
+          'color' => 'sky',
+          'icon' => '✓',
+      ];
+  } elseif (session('book_returned')) {
+      $flash = [
+          'type' => 'success',
+          'title' => '返却処理が完了しました',
+          'message' => session('book_returned'),
+          'color' => 'emerald',
+          'icon' => '✓',
+      ];
+  }
+@endphp
+
+@if ($flash)
+  <div class="max-w-6xl mx-auto mt-6 px-4">
+    <div
+      id="flash-message"
+      class="
+        flex items-start gap-3 rounded-xl px-5 py-4 shadow-sm border
+        @if ($flash['color'] === 'emerald')
+          border-emerald-200 bg-emerald-50 text-emerald-800
+        @elseif ($flash['color'] === 'red')
+          border-red-200 bg-red-50 text-red-800
+        @elseif ($flash['color'] === 'sky')
+          border-sky-200 bg-sky-50 text-sky-800
+        @endif
+      "
+      role="alert"
+    >
+      <div
+        class="
+          flex h-8 w-8 shrink-0 items-center justify-center rounded-full
+          @if ($flash['color'] === 'emerald')
+            bg-emerald-100 text-emerald-700
+          @elseif ($flash['color'] === 'red')
+            bg-red-100 text-red-700
+          @elseif ($flash['color'] === 'sky')
+            bg-sky-100 text-sky-700
+          @endif
+        "
+      >
+        {{ $flash['icon'] }}
+      </div>
+
+      <div class="flex-1">
+        <div class="font-bold">{{ $flash['title'] }}</div>
+        <div class="mt-1 text-sm">
+          {{ $flash['message'] }}
+        </div>
+      </div>
+
+      <button
+        type="button"
+        id="close-flash"
+        class="ml-4 opacity-70 hover:opacity-100"
+        aria-label="閉じる"
+      >
+        ×
+      </button>
     </div>
-  @endif
+  </div>
+@endif
   <div class="max-w-6xl mx-auto mt-12 bg-white rounded-xl shadow-lg p-8">
     <h1 class="text-center text-[var(--color-primary)] text-[var(--text-title)] font-bold mb-8 tracking-wide">
       すべての図書
@@ -369,6 +451,26 @@
 <script>
 document.addEventListener('DOMContentLoaded', function() {
   let targetForm = null;
+
+  //自動で閉じる
+  const flashMessage = document.getElementById('flash-message');
+  const closeFlash = document.getElementById('close-flash');
+
+  closeFlash?.addEventListener('click', () => {
+    flashMessage?.remove();
+  });
+
+  if (flashMessage) {
+    setTimeout(() => {
+      flashMessage.style.transition = 'opacity 0.4s ease, transform 0.4s ease';
+      flashMessage.style.opacity = '0';
+      flashMessage.style.transform = 'translateY(-8px)';
+
+      setTimeout(() => {
+        flashMessage.remove();
+      }, 400);
+    }, 4000);
+  }
 
   // 追加・削除モーダルの処理
   const addBg = document.getElementById('modal-bg-add-book');

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,7 +51,6 @@ Route::get('/borrowing-records', [BookController::class, 'index'])->name('books.
 // 返却処理
 Route::post('/books/{id}/return', [BookController::class, 'return'])->name('books.return');
 Route::post('/borrow', [BookController::class, 'borrow']);
-Route::post('/return', [BookController::class, 'return']);
 
 // APIエンドポイント
 Route::get('/api/search_book', [ApiController::class, 'search_book'])


### PR DESCRIPTION
## 概要
Open Library APIを利用して、書籍追加画面から外部API検索できるように接続しました。

## 変更内容
- Open Library APIへの接続処理を追加
- 検索結果を一覧表示し、選択した書籍情報を登録フォームへ反映
- 書籍追加・削除・貸出・返却時のフラッシュメッセージを整理
- 不要な返却ルートを削除し、`books/{id}/return` に統一

## 確認したこと
- `php artisan route:list` で不要な `POST return` が消えていることを確認
- 管理画面から書籍検索・追加・削除ができることを確認