### PR TITLE
図書一覧に絞り込み・並び替え・ページネーションを追加

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ return [
             'database' => env('DB_DATABASE', database_path('database.sqlite')),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
-            'busy_timeout' => null,
+            'busy_timeout' => 5000,
             'journal_mode' => null,
             'synchronous' => null,
         ],

--- a/database/migrations/2026_04_29_000000_rename_field_to_location_in_books_table.php
+++ b/database/migrations/2026_04_29_000000_rename_field_to_location_in_books_table.php
@@ -1,4 +1,3 @@
-<!-- DBの列名変更をするmigrationファイル -->
 <?php
 
 use Illuminate\Database\Migrations\Migration;

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -165,6 +165,122 @@
       すべての図書
     </h1>
 
+    @if ($errors->any())
+      <div class="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+        <div class="font-semibold">入力内容を確認してください。</div>
+        <ul class="mt-2 list-disc pl-5">
+          @foreach ($errors->all() as $error)
+            <li>{{ $error }}</li>
+          @endforeach
+        </ul>
+      </div>
+    @endif
+
+    <form method="GET" action="{{ url('/') }}" class="mb-4 rounded-lg border border-gray-200 bg-[var(--color-background)] p-4 shadow-sm">
+      <input type="hidden" name="sort" value="{{ $sort ?? 'title_asc' }}">
+      <div class="grid grid-cols-1 md:grid-cols-[1fr_180px_180px_auto] gap-3 items-end">
+        <div>
+          <label for="book-keyword" class="block text-sm font-semibold text-gray-700 mb-1">キーワード検索</label>
+          <input
+            id="book-keyword"
+            name="keyword"
+            type="search"
+            value="{{ $keyword ?? '' }}"
+            placeholder="タイトル・著者・出版年など"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20"
+          >
+        </div>
+
+        <div>
+          <label for="book-location" class="block text-sm font-semibold text-gray-700 mb-1">所在</label>
+          <select
+            id="book-location"
+            name="location"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20"
+          >
+            <option value="" @selected(($location ?? '') === '')>すべて</option>
+            <option value="206" @selected(($location ?? '') === '206')>206</option>
+            <option value="300" @selected(($location ?? '') === '300')>300</option>
+          </select>
+        </div>
+
+        <div>
+          <label for="book-availability" class="block text-sm font-semibold text-gray-700 mb-1">貸出状況</label>
+          <select
+            id="book-availability"
+            name="availability"
+            class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-[var(--color-primary)] focus:outline-none focus:ring-2 focus:ring-[var(--color-primary)]/20"
+          >
+            <option value="" @selected(($availability ?? '') === '')>すべて</option>
+            <option value="available" @selected(($availability ?? '') === 'available')>在庫あり</option>
+            <option value="borrowed" @selected(($availability ?? '') === 'borrowed')>貸出中</option>
+          </select>
+        </div>
+
+        <div class="flex gap-2">
+          <button type="submit" class="rounded-md bg-[var(--color-primary)] px-4 py-2 text-sm font-semibold text-white transition hover:opacity-90">
+            検索
+          </button>
+          <a href="{{ url('/') }}" class="rounded-md border border-gray-300 px-4 py-2 text-sm font-semibold text-gray-700 transition hover:bg-white">
+            クリア
+          </a>
+        </div>
+      </div>
+    </form>
+
+    @php
+      $activeSort = $sort ?? 'title_asc';
+      $availabilityLabels = [
+          '' => 'すべて',
+          'available' => '在庫あり',
+          'borrowed' => '貸出中',
+      ];
+      $sortTabs = [
+          'title_asc' => 'タイトル 昇順',
+          'title_desc' => 'タイトル 降順',
+          'author_asc' => '著者 昇順',
+          'author_desc' => '著者 降順',
+          'year_asc' => '出版年 古い順',
+          'year_desc' => '出版年 新しい順',
+          'created_desc' => '登録日 新しい順',
+          'created_asc' => '登録日 古い順',
+      ];
+    @endphp
+
+    <div class="mb-6 flex flex-wrap gap-2 border-b border-gray-200 pb-3">
+      @foreach ($sortTabs as $sortValue => $sortLabel)
+        @php
+          $sortUrl = url('/') . '?' . http_build_query(array_filter([
+              'keyword' => $keyword ?? '',
+              'location' => $location ?? '',
+              'availability' => $availability ?? '',
+              'sort' => $sortValue,
+          ], fn ($value) => $value !== '' && $value !== null));
+        @endphp
+        <a
+          href="{{ $sortUrl }}"
+          class="rounded-md border px-3 py-2 text-sm font-semibold transition
+            @if ($activeSort === $sortValue)
+              border-[var(--color-primary)] bg-[var(--color-primary)] text-white
+            @else
+              border-gray-300 bg-white text-gray-700 hover:border-[var(--color-primary)] hover:text-[var(--color-primary)]
+            @endif"
+        >
+          {{ $sortLabel }}
+        </a>
+      @endforeach
+    </div>
+
+    <div class="mb-4 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700">
+      <div class="font-semibold">表示件数: {{ $books->total() }}件</div>
+      <div class="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-gray-600">
+        <span>キーワード: {{ ($keyword ?? '') !== '' ? $keyword : '指定なし' }}</span>
+        <span>所在: {{ ($location ?? '') !== '' ? $location : 'すべて' }}</span>
+        <span>貸出状況: {{ $availabilityLabels[$availability ?? ''] ?? 'すべて' }}</span>
+        <span>並び替え: {{ $sortTabs[$activeSort] ?? $sortTabs['title_asc'] }}</span>
+      </div>
+    </div>
+
     <div class="flex flex-col lg:flex-row gap-6 items-start">
       {{-- 左：本一覧 --}}
       <div class="flex-1 min-w-0">
@@ -179,7 +295,7 @@
             </tr>
           </thead>
           <tbody>
-            @foreach($books as $book)
+            @forelse($books as $book)
               <tr class="even:bg-gray-100 hover:bg-[var(--color-accent)]/10 transition">
                 <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->book_title }}</td>
                 <td class="px-6 py-4 text-[var(--text-body)]">{{ $book->author }}</td>
@@ -233,9 +349,24 @@
                   <td class="hidden">{{ $book->borrower }}</td>
                 @endif
               </tr>
-            @endforeach
+            @empty
+              <tr>
+                <td colspan="5" class="px-6 py-8 text-center text-sm text-gray-600">
+                  条件に一致する図書はありません。
+                </td>
+              </tr>
+            @endforelse
           </tbody>
       </table>
+
+      <div class="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div class="text-sm font-semibold text-gray-600">
+          {{ $books->currentPage() }} / {{ $books->lastPage() }}
+        </div>
+        <div>
+          {{ $books->links() }}
+        </div>
+      </div>
     </div>
 
        {{-- 右：追加/削除ボタン--}}
@@ -420,7 +551,7 @@
 
     <div class="text-sm text-gray-700 max-h-[60vh] overflow-auto">
       <ul class="space-y-2">
-        @foreach($books as $book)
+        @foreach($allBooksForManagement ?? $books as $book)
           <li class="flex items-center justify-between gap-3 border rounded-lg p-3 bg-white">
             <div class="min-w-0">
               <div class="font-semibold truncate">{{ $book->book_title }}</div>
@@ -816,7 +947,7 @@ document.addEventListener('DOMContentLoaded', function() {
       targetForm = form;
       const bookId = form.querySelector('input[name="id"]').value;
       const bookTitle = form.closest('tr').querySelector('td:nth-child(1)').textContent;
-      const borrower = form.closest('tr').querySelector('td:nth-child(5)')?.textContent || '';
+      const borrower = form.closest('tr').querySelector('td:nth-child(6)')?.textContent || '';
       const modalBg = document.getElementById(`modal-bg-${bookId}-return`);
       const modalBookInfo = document.getElementById(`modal-bookinfo-${bookId}-return`);
       if (modalBookInfo) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,21 +1,88 @@
 <?php
 
 use App\Models\Book;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Facades\DB;
 use App\Http\Controllers\BookController;
 use App\Http\Controllers\ApiController;
 
 // テスト画面
-Route::get('/', function () {
-    $books = Book::all();
-    if (session('success')) {
-        return view('home', [
-            'books' => $books,
-            'success' => session('success'),
-        ]);
+Route::get('/', function (Request $request) {
+    $keyword = trim((string) $request->query('keyword', ''));
+    $location = (string) $request->query('location', '');
+    $availability = (string) $request->query('availability', '');
+    $sort = (string) $request->query('sort', 'title_asc');
+
+    $sortOptions = [
+        'title_asc' => ['book_title', 'asc'],
+        'title_desc' => ['book_title', 'desc'],
+        'author_asc' => ['author', 'asc'],
+        'author_desc' => ['author', 'desc'],
+        'year_asc' => ['published_year', 'asc'],
+        'year_desc' => ['published_year', 'desc'],
+        'created_desc' => ['created_at', 'desc'],
+        'created_asc' => ['created_at', 'asc'],
+    ];
+
+    if (! array_key_exists($sort, $sortOptions)) {
+        $sort = 'title_asc';
     }
-    return view('home', compact('books'));
+
+    if (! in_array($location, ['', '206', '300'], true)) {
+        $location = '';
+    }
+
+    if (! in_array($availability, ['', 'available', 'borrowed'], true)) {
+        $availability = '';
+    }
+
+    $booksQuery = Book::query();
+
+    if ($keyword !== '') {
+        $booksQuery->where(function ($query) use ($keyword) {
+            $likeKeyword = '%' . $keyword . '%';
+
+            $query->where('book_title', 'like', $likeKeyword)
+                ->orWhere('author', 'like', $likeKeyword)
+                ->orWhere('published_year', 'like', $likeKeyword)
+                ->orWhere('location', 'like', $likeKeyword)
+                ->orWhere('borrower', 'like', $likeKeyword);
+        });
+    }
+
+    if ($location !== '') {
+        $booksQuery->where('location', $location);
+    }
+
+    if ($availability === 'borrowed') {
+        $booksQuery
+            ->whereNotNull('borrower')
+            ->where('borrower', '!=', '')
+            ->where('borrower', '!=', '借りていない');
+    } elseif ($availability === 'available') {
+        $booksQuery->where(function ($query) {
+            $query->whereNull('borrower')
+                ->orWhere('borrower', '')
+                ->orWhere('borrower', '借りていない');
+        });
+    }
+
+    [$sortColumn, $sortDirection] = $sortOptions[$sort];
+    $books = $booksQuery
+        ->orderBy($sortColumn, $sortDirection)
+        ->orderBy('id')
+        ->paginate(20)
+        ->withQueryString();
+    $allBooksForManagement = Book::orderBy('book_title')->orderBy('id')->get();
+
+    $viewData = compact('books', 'allBooksForManagement', 'keyword', 'location', 'availability', 'sort');
+
+    if (session('success')) {
+        $viewData['success'] = session('success');
+    }
+
+    return view('home', $viewData);
 });
 
 Route::get('test', function() {

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -2,11 +2,13 @@
 
 namespace Tests\Feature;
 
-// use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class ExampleTest extends TestCase
 {
+    use RefreshDatabase;
+
     /**
      * A basic test example.
      */


### PR DESCRIPTION
## 概要
図書一覧に検索・絞り込み・並び替え・ページネーション機能を追加しました。

## 変更内容
- キーワード検索を追加
- 所在による絞り込みを追加
- 貸出状況による絞り込みを追加
- タブ形式の並び替えを追加
- 検索条件と表示件数を表示
- 20件ごとのページネーションを追加